### PR TITLE
Fix step size attribute in symptom slider

### DIFF
--- a/app/src/main/res/layout/activity_regis_sintomas.xml
+++ b/app/src/main/res/layout/activity_regis_sintomas.xml
@@ -52,7 +52,7 @@
             android:contentDescription="@string/label_intensidad"
             app:valueFrom="0"
             app:valueTo="10"
-            app:stepSize="1"
+            android:stepSize="1"
             app:value="0" />
 
         <!-- Fecha (abre DatePicker) -->


### PR DESCRIPTION
## Summary
- replace deprecated `app:stepSize` with `android:stepSize` in symptom registration slider

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a397fc4a24832a8c3accf9f2deb7a0