### PR TITLE
Finish login activity after successful sign-in

### DIFF
--- a/app/src/main/java/com/example/symptotrack/MainActivity.java
+++ b/app/src/main/java/com/example/symptotrack/MainActivity.java
@@ -109,11 +109,11 @@ public class MainActivity extends AppCompatActivity {
                 new com.example.symptotrack.auth.SessionManager(MainActivity.this)
                         .saveLogin(data.role, data.id);
 
-                if ("doctor".equalsIgnoreCase(data.role)) {
-                    startActivity(new Intent(MainActivity.this, com.example.symptotrack.doctor.Vista_doctor.class));
-                } else {
-                    startActivity(new Intent(MainActivity.this, Inicio.class));
-                }
+                Intent next = "doctor".equalsIgnoreCase(data.role)
+                        ? new Intent(MainActivity.this, com.example.symptotrack.doctor.Vista_doctor.class)
+                        : new Intent(MainActivity.this, Inicio.class);
+                startActivity(next);
+                finish();
             }
             @Override public void onFailure(Call<ApiResponse<LoginResponse>> call, Throwable t) {
                 Toast.makeText(MainActivity.this, "Error de red: " + t.getMessage(), Toast.LENGTH_SHORT).show();


### PR DESCRIPTION
## Summary
- finish MainActivity after successful login to remove it from the back stack

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden" )*

------
https://chatgpt.com/codex/tasks/task_e_68a574a10bd4832aaddebb4509ae4fb7