### PR TITLE
Fix doctor activity paths in manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,10 +16,10 @@
         android:theme="@style/Theme.SymptoTrack"
         tools:targetApi="31">
         <activity
-            android:name=".doctor.DetallePaciente"
+            android:name=".Doc.DetallePaciente"
             android:exported="false" />
         <activity
-            android:name=".doctor.ListaPacientes"
+            android:name=".Doc.ListaPacientes"
             android:exported="false" />
         <activity
             android:name=".doctor.Vista_doctor"


### PR DESCRIPTION
## Summary
- correct doctor activity package names in AndroidManifest

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68a57fe94f8c832a86da09031c1d3dc3