### PR TITLE
Register SelectDoctor activity in manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,9 @@
             android:name=".Registrar"
             android:exported="false" />
         <activity
+            android:name=".SelectDoctor"
+            android:exported="false" />
+        <activity
             android:name=".MainActivity"
             android:exported="true">
             <intent-filter>


### PR DESCRIPTION
## Summary
- register SelectDoctor activity in Android manifest

## Testing
- `bash gradlew assembleDebug` *(fails: Unable to tunnel through proxy, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a583dc87cc832abe8f136cf16525a7