### PR TITLE
Validate patient ID before loading details

### DIFF
--- a/app/src/main/java/com/example/symptotrack/Doc/DetallePaciente.java
+++ b/app/src/main/java/com/example/symptotrack/Doc/DetallePaciente.java
@@ -49,6 +49,12 @@ public class DetallePaciente extends AppCompatActivity {
         rvNotas.setAdapter(adapter);
 
         long patientId = getIntent().getLongExtra("patient_id", -1);
+        if (patientId < 0) {
+            Toast.makeText(this, "ID de paciente inválido", Toast.LENGTH_SHORT).show();
+            finish();
+            return;
+        }
+
         String patientName = getIntent().getStringExtra("patient_name");
         tvNombre.setText(patientName != null ? patientName : "Paciente");
 


### PR DESCRIPTION
## Summary
- Stop `DetallePaciente` early when patient ID is invalid by showing an error toast and finishing the activity
- Invoke `cargarDetalle` only after a valid patient ID is provided

## Testing
- `sh gradlew test` *(fails: Unable to tunnel through proxy, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6077e4fc0832a83dfb866a253c06e