### PR TITLE
Use long for patient IDs

### DIFF
--- a/app/src/main/java/com/example/symptotrack/Doc/ListaPacientes.java
+++ b/app/src/main/java/com/example/symptotrack/Doc/ListaPacientes.java
@@ -62,7 +62,7 @@ public class ListaPacientes extends AppCompatActivity {
                 }
                 List<PatientItem> ui = new ArrayList<>();
                 for (PatientSummaryDto s : resp.body().data) {
-                    ui.add(new PatientItem((int)s.patient_id, s.patient_fullname, s.last_shared_date));
+                    ui.add(new PatientItem(s.patient_id, s.patient_fullname, s.last_shared_date));
                 }
                 adapter.submit(ui);
             }

--- a/app/src/main/java/com/example/symptotrack/Doc/PatientItem.java
+++ b/app/src/main/java/com/example/symptotrack/Doc/PatientItem.java
@@ -1,11 +1,11 @@
 package com.example.symptotrack.Doc;
 
 public class PatientItem {
-    public final int id;
+    public final long id;
     public final String nombreCompleto;
     public final String ultimoEnvio; // fecha texto
 
-    public PatientItem(int id, String nombreCompleto, String ultimoEnvio) {
+    public PatientItem(long id, String nombreCompleto, String ultimoEnvio) {
         this.id = id;
         this.nombreCompleto = nombreCompleto;
         this.ultimoEnvio = ultimoEnvio;


### PR DESCRIPTION
## Summary
- switch `PatientItem` id from int to long
- propagate long ids through patient list loading

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a6078947ac832a82affbc5978ae3d5