### PR TITLE
Fix user registration and doctor name compilation errors

### DIFF
--- a/app/src/main/java/com/example/symptotrack/Registrar.java
+++ b/app/src/main/java/com/example/symptotrack/Registrar.java
@@ -65,19 +65,19 @@ public class Registrar extends AppCompatActivity {
                         etContrasena.getText().toString()             // texto plano (modo demo)
                 );
 
-                api.registerUser(body).enqueue(new Callback<ApiResponse<UserData>>() {
-                    @Override public void onResponse(Call<ApiResponse<UserData>> call, Response<ApiResponse<UserData>> resp) {
+                api.registerUser(body).enqueue(new Callback<ApiResponse<CreatedId>>() {
+                    @Override public void onResponse(Call<ApiResponse<CreatedId>> call, Response<ApiResponse<CreatedId>> resp) {
                         if (!resp.isSuccessful() || resp.body() == null || !resp.body().ok) {
                             String mensaje = (resp.body()!=null && resp.body().error!=null) ? resp.body().error : "Registro fallido";
                             Toast.makeText(Registrar.this, mensaje, Toast.LENGTH_SHORT).show();
                             return;
                         }
-                        UserData u = resp.body().data;
-                        Toast.makeText(Registrar.this, "Registrado: " + u.first_name + " " + u.last_name, Toast.LENGTH_SHORT).show();
+                        CreatedId u = resp.body().data;
+                        Toast.makeText(Registrar.this, "Registrado (id " + u.id + ")", Toast.LENGTH_SHORT).show();
                         finish(); // vuelve al login
                     }
 
-                    @Override public void onFailure(Call<ApiResponse<UserData>> call, Throwable t) {
+                    @Override public void onFailure(Call<ApiResponse<CreatedId>> call, Throwable t) {
                         Toast.makeText(Registrar.this, "Error de red: " + t.getMessage(), Toast.LENGTH_SHORT).show();
                     }
                 });

--- a/app/src/main/java/com/example/symptotrack/SelectDoctor.java
+++ b/app/src/main/java/com/example/symptotrack/SelectDoctor.java
@@ -72,7 +72,8 @@ public class SelectDoctor extends AppCompatActivity {
                 }
                 List<DoctorItem> ui = new ArrayList<>();
                 for (DoctorDto d : resp.body().data) {
-                    ui.add(new DoctorItem(d.doctor_id, d.nombreCompleto(), d.email));
+                    String nombreCompleto = d.first_name + " " + d.last_name;
+                    ui.add(new DoctorItem(d.doctor_id, nombreCompleto, d.email));
                 }
                 adapter.submit(ui);
             }


### PR DESCRIPTION
## Summary
- Use `CreatedId` when registering a new user to match API contract
- Build doctor full name from first and last names instead of calling removed `nombreCompleto()`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a66e19eff0832a9ca7bfda865f65d2