### PR TITLE
Add admin activity and fix patient detail display

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,9 @@
         android:theme="@style/Theme.SymptoTrack"
         tools:targetApi="31">
         <activity
+            android:name=".admin.AdminActivity"
+            android:exported="false" />
+        <activity
             android:name=".Doc.DetallePaciente"
             android:exported="false" />
         <activity

--- a/app/src/main/java/com/example/symptotrack/Doc/DetallePaciente.java
+++ b/app/src/main/java/com/example/symptotrack/Doc/DetallePaciente.java
@@ -23,7 +23,7 @@ import retrofit2.Response;
 
 public class DetallePaciente extends AppCompatActivity {
 
-    private TextView tvNombre, tvInfo, tvEmail, tvUsername;
+    private TextView tvNombre, tvInfo;
     private ImageView imgLogo;
     private RecyclerView rvNotas;
     private NotesAdapter adapter;
@@ -76,8 +76,7 @@ public class DetallePaciente extends AppCompatActivity {
                 }
                 PatientDetailDto d = resp.body().data;
                 tvNombre.setText(d.first_name + " " + d.last_name);
-                tvEmail.setText(d.email);
-                tvUsername.setText(d.username);
+                tvInfo.setText(d.email + " · " + d.username);
 
 
                 List<NoteItem> notes = new ArrayList<>();


### PR DESCRIPTION
## Summary
- Register `AdminActivity` in the manifest so admin login can open the panel
- Replace unused email/username fields in `DetallePaciente` with combined contact info to avoid crashes

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6762d3988832a86bdb1616055cf1f