### PR TITLE
Show backend error when patient list fails to load

### DIFF
--- a/app/src/main/java/com/example/symptotrack/Doc/ListaPacientes.java
+++ b/app/src/main/java/com/example/symptotrack/Doc/ListaPacientes.java
@@ -59,7 +59,10 @@ public class ListaPacientes extends AppCompatActivity {
                     public void onResponse(retrofit2.Call<ApiResponse<java.util.List<PatientSummaryDto>>> call,
                                            retrofit2.Response<ApiResponse<java.util.List<PatientSummaryDto>>> resp) {
                         if (!resp.isSuccessful() || resp.body() == null || !resp.body().ok || resp.body().data == null) {
-                            Toast.makeText(ListaPacientes.this, "No se pudo cargar los pacientes", Toast.LENGTH_SHORT).show();
+                            String msg = resp.body() != null && resp.body().error != null
+                                    ? resp.body().error
+                                    : "No se pudo cargar los pacientes";
+                            Toast.makeText(ListaPacientes.this, msg, Toast.LENGTH_SHORT).show();
                             return;
                         }
                         java.util.List<PatientSummaryDto> lista = resp.body().data;


### PR DESCRIPTION
## Summary
- Show backend-provided error message when loading patient list fails

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a684686ab0832a97e76b9af1cb4bc9