### PR TITLE
Validate doctor ID before loading patients

### DIFF
--- a/app/src/main/java/com/example/symptotrack/Doc/ListaPacientes.java
+++ b/app/src/main/java/com/example/symptotrack/Doc/ListaPacientes.java
@@ -53,6 +53,10 @@ public class ListaPacientes extends AppCompatActivity {
             return;
         }
         int doctorId = (int) session.getId();
+        if (doctorId <= 0) {
+            Toast.makeText(this, "ID de doctor inválido. Vuelva a iniciar sesión.", Toast.LENGTH_SHORT).show();
+            return;
+        }
         api.listPatientsForDoctor(doctorId)
                 .enqueue(new retrofit2.Callback<ApiResponse<java.util.List<PatientSummaryDto>>>() {
                     @Override


### PR DESCRIPTION
## Summary
- ensure doctor ID is valid before fetching patients

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6846b9324832ab247871ee209bf85