### PR TITLE
Pass authorization token when fetching doctor's patients

### DIFF
--- a/app/src/main/java/com/example/symptotrack/Doc/ListaPacientes.java
+++ b/app/src/main/java/com/example/symptotrack/Doc/ListaPacientes.java
@@ -57,7 +57,12 @@ public class ListaPacientes extends AppCompatActivity {
             Toast.makeText(this, "ID de doctor inválido. Vuelva a iniciar sesión.", Toast.LENGTH_SHORT).show();
             return;
         }
-        api.listPatientsForDoctor(doctorId)
+        String token = session.token();
+        if (token == null || token.isEmpty()) {
+            Toast.makeText(this, "Token inválido. Vuelva a iniciar sesión.", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        api.listPatientsForDoctor(token, doctorId)
                 .enqueue(new retrofit2.Callback<ApiResponse<java.util.List<PatientSummaryDto>>>() {
                     @Override
                     public void onResponse(retrofit2.Call<ApiResponse<java.util.List<PatientSummaryDto>>> call,

--- a/app/src/main/java/com/example/symptotrack/net/ApiService.java
+++ b/app/src/main/java/com/example/symptotrack/net/ApiService.java
@@ -85,7 +85,10 @@ public interface ApiService {
 
     // Listar pacientes que compartieron con un doctor
     @GET("doctors/{doctor_id}/patients")
-    Call<ApiResponse<List<PatientSummaryDto>>> listPatientsForDoctor(@Path("doctor_id") int doctorId);
+    Call<ApiResponse<List<PatientSummaryDto>>> listPatientsForDoctor(
+            @Header("Authorization") String token,
+            @Path("doctor_id") int doctorId
+    );
 
     @GET("patients/{patient_id}/detail")
     Call<ApiResponse<PatientDetailDto>> patientDetail(

--- a/app/src/main/java/com/example/symptotrack/session/SessionManager.java
+++ b/app/src/main/java/com/example/symptotrack/session/SessionManager.java
@@ -18,17 +18,30 @@ public class SessionManager {
 
     // Estilo nuevo
     public void save(String role, long id) {
-        sp.edit().putString("role", role).putLong("id", id).apply();
+        save(role, id, token());
+    }
+
+    public void save(String role, long id, String token) {
+        sp.edit().putString("role", role)
+                .putLong("id", id)
+                .putString("token", token)
+                .apply();
+    }
+
+    public void saveToken(String token) {
+        sp.edit().putString("token", token).apply();
     }
 
     // ----- Lectura -----
     // Estilo nuevo (corto)
     public String role() { return sp.getString("role", null); }
     public long id()     { return sp.getLong("id", -1); }
+    public String token() { return sp.getString("token", null); }
 
     // Estilo antiguo (getters largos)
     public String getRole() { return role(); }
     public long getId()     { return id(); }
+    public String getToken() { return token(); }
 
     // ----- Helpers -----
     public boolean isUser()   { return "user".equalsIgnoreCase(role()); }


### PR DESCRIPTION
## Summary
- send Authorization header in `listPatientsForDoctor`
- retrieve and forward stored session token when loading patients
- extend `SessionManager` to save and retrieve auth tokens

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a68790f61c832a8bc17f68d2534195