### PR TITLE
Configure API base URL per environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Sympto-Track
+
+## Configuración de la URL base de la API
+
+La URL que utiliza la aplicación para conectarse con el servidor se define en `app/build.gradle.kts` a través de *product flavors*.
+
+### Entornos disponibles
+
+- **emulator**: usa la IP especial `10.0.2.2` que permite que el emulador acceda al servidor en tu máquina local.
+- **device**: pensado para un dispositivo físico en la misma red local. Cambia la IP por la de tu ordenador dentro de la red.
+- **production**: apunta al servidor en producción.
+
+### Cambiar la URL
+
+1. Abre `app/build.gradle.kts` y localiza la sección `productFlavors`.
+2. Ajusta el valor de `BASE_URL` según el entorno que quieras modificar.
+3. Compila la aplicación seleccionando el flavor correspondiente. Por ejemplo:
+   - `./gradlew assembleEmulatorDebug`
+   - `./gradlew assembleDeviceDebug`
+   - `./gradlew assembleProductionRelease`
+
+Cada flavor genera una clase `BuildConfig` con su propio `BASE_URL`, utilizado automáticamente por `ApiClient`.
+

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,22 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    flavorDimensions += "environment"
+    productFlavors {
+        create("emulator") {
+            dimension = "environment"
+            buildConfigField("String", "BASE_URL", "\"http://10.0.2.2:8000/\"")
+        }
+        create("device") {
+            dimension = "environment"
+            buildConfigField("String", "BASE_URL", "\"http://192.168.0.13:8000/\"")
+        }
+        create("production") {
+            dimension = "environment"
+            buildConfigField("String", "BASE_URL", "\"https://symptotrack.example.com/\"")
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -28,6 +44,9 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+    buildFeatures {
+        buildConfig = true
     }
 }
 

--- a/app/src/main/java/com/example/symptotrack/net/ApiClient.java
+++ b/app/src/main/java/com/example/symptotrack/net/ApiClient.java
@@ -1,15 +1,13 @@
 package com.example.symptotrack.net;
 
+import com.example.symptotrack.BuildConfig;
+
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 public class ApiClient {
-    // Emulador Android
-    private static final String BASE_URL = "http://10.0.2.2:8000/";
-    // Teléfono real (misma Wi-Fi): usa la IP de tu PC, ej:
-    // private static final String BASE_URL = "http://192.168.0.13:8000/";
 
     private static Retrofit retrofit;
 
@@ -22,7 +20,7 @@ public class ApiClient {
                     .build();
 
             retrofit = new Retrofit.Builder()
-                    .baseUrl(BASE_URL)
+                    .baseUrl(BuildConfig.BASE_URL)
                     .client(http)
                     .addConverterFactory(GsonConverterFactory.create())
                     .build();


### PR DESCRIPTION
## Summary
- Move Retrofit client to use `BuildConfig.BASE_URL` instead of hard-coded constant
- Add emulator, device, and production product flavors with their own base URLs and enable BuildConfig generation
- Document how to change the API URL for each environment

## Testing
- `./gradlew testEmulatorDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a68796a638832a98da89e8e81cebac