### PR TITLE
Use long for doctor identifiers

### DIFF
--- a/app/src/main/java/com/example/symptotrack/Doc/DetallePaciente.java
+++ b/app/src/main/java/com/example/symptotrack/Doc/DetallePaciente.java
@@ -66,7 +66,7 @@ public class DetallePaciente extends AppCompatActivity {
             Toast.makeText(this, "Debes iniciar sesión como doctor", Toast.LENGTH_SHORT).show();
             return;
         }
-        int doctorId = (int) session.getId();
+        long doctorId = session.getId();
 
         api.patientDetail(doctorId, patientId).enqueue(new Callback<ApiResponse<PatientDetailDto>>() {
             @Override public void onResponse(Call<ApiResponse<PatientDetailDto>> call, Response<ApiResponse<PatientDetailDto>> resp) {

--- a/app/src/main/java/com/example/symptotrack/Doc/ListaPacientes.java
+++ b/app/src/main/java/com/example/symptotrack/Doc/ListaPacientes.java
@@ -52,7 +52,7 @@ public class ListaPacientes extends AppCompatActivity {
             Toast.makeText(this, "Debes iniciar sesión como doctor", Toast.LENGTH_SHORT).show();
             return;
         }
-        int doctorId = (int) session.getId();
+        long doctorId = session.getId();
         if (doctorId <= 0) {
             Toast.makeText(this, "ID de doctor inválido. Vuelva a iniciar sesión.", Toast.LENGTH_SHORT).show();
             return;

--- a/app/src/main/java/com/example/symptotrack/doctor/DoctorItem.java
+++ b/app/src/main/java/com/example/symptotrack/doctor/DoctorItem.java
@@ -1,11 +1,11 @@
 package com.example.symptotrack.doctor;
 
 public class DoctorItem {
-    public final int id;
+    public final long id;
     public final String nombreCompleto;
     public final String email;
 
-    public DoctorItem(int id, String nombreCompleto, String email) {
+    public DoctorItem(long id, String nombreCompleto, String email) {
         this.id = id;
         this.nombreCompleto = nombreCompleto;
         this.email = email;

--- a/app/src/main/java/com/example/symptotrack/net/ApiService.java
+++ b/app/src/main/java/com/example/symptotrack/net/ApiService.java
@@ -50,7 +50,7 @@ public interface ApiService {
     Call<ApiResponse<GenericOk>> adminSetDoctorStatus(
             @Header("X-Admin-User") String adminUser,
             @Header("X-Admin-Pass") String adminPass,
-            @Path("doctor_id") int doctorId,
+            @Path("doctor_id") long doctorId,
             @Body StatusRequest body
     );
 
@@ -85,11 +85,11 @@ public interface ApiService {
 
     // Listar pacientes que compartieron con un doctor
     @GET("doctors/{doctor_id}/patients")
-    Call<ApiResponse<List<PatientSummaryDto>>> listPatientsForDoctor(@Path("doctor_id") int doctorId);
+    Call<ApiResponse<List<PatientSummaryDto>>> listPatientsForDoctor(@Path("doctor_id") long doctorId);
 
     @GET("patients/{patient_id}/detail")
     Call<ApiResponse<PatientDetailDto>> patientDetail(
-            @Query("doctor_id") int doctorId,
+            @Query("doctor_id") long doctorId,
             @Path("patient_id") long patientId
     );
 

--- a/app/src/main/java/com/example/symptotrack/net/dto/DoctorDto.java
+++ b/app/src/main/java/com/example/symptotrack/net/dto/DoctorDto.java
@@ -1,7 +1,7 @@
 package com.example.symptotrack.net.dto;
 
 public class DoctorDto {
-    public int doctor_id;
+    public long doctor_id;
     public String first_name;
     public String last_name;
     public String email;

--- a/app/src/main/java/com/example/symptotrack/net/dto/LoginData.java
+++ b/app/src/main/java/com/example/symptotrack/net/dto/LoginData.java
@@ -2,7 +2,7 @@ package com.example.symptotrack.net.dto;
 
 public class LoginData {
     public String role; // "user" o "doctor"
-    public int id;      // id de user o doctor_id
+    public long id;      // id de user o doctor_id
     public String first_name;
     public String last_name;
 }

--- a/app/src/main/java/com/example/symptotrack/net/dto/ShareRequest.java
+++ b/app/src/main/java/com/example/symptotrack/net/dto/ShareRequest.java
@@ -1,12 +1,12 @@
 package com.example.symptotrack.net.dto;
 
 public class ShareRequest {
-    public int doctor_id;
+    public long doctor_id;
     public long patient_id;
     public String note;   // opcional
     public String fecha;  // "yyyy-MM-dd" opcional
 
-    public ShareRequest(int doctor_id, long patient_id, String note, String fecha) {
+    public ShareRequest(long doctor_id, long patient_id, String note, String fecha) {
         this.doctor_id = doctor_id;
         this.patient_id = patient_id;
         this.note = note;

--- a/app/src/main/java/com/example/symptotrack/net/dto/ShareResponse.java
+++ b/app/src/main/java/com/example/symptotrack/net/dto/ShareResponse.java
@@ -2,7 +2,7 @@ package com.example.symptotrack.net.dto;
 
 public class ShareResponse {
     public long id;
-    public int doctor_id;
+    public long doctor_id;
     public long patient_id;
     public String fecha;
 }


### PR DESCRIPTION
## Summary
- Use `long` for doctor ID parameters in `ApiService`
- Pass session doctor IDs without casting in doctor screens
- Align DTOs and view models to store doctor IDs as `long`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6879e9514832aa45144c0afe710be